### PR TITLE
Catch nested EOFException thrown in NormalizedKeySorter

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java
@@ -296,7 +296,15 @@ public final class NormalizedKeySorter<T> implements InMemorySorter<T> {
         try {
             this.serializer.serialize(record, this.recordCollector);
         } catch (EOFException e) {
+            LOG.warn("RecordCollector out of memory");
             return false;
+        } catch (Exception e) {
+            if (e.getCause().getClass().equals(EOFException.class)) {
+                LOG.warn("RecordCollector out of memory");
+                return false;
+            } else {
+                throw e;
+            }
         }
 
         final long newOffset = this.recordCollector.getCurrentOffset();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The [NormalizedKeySorter library](https://github.com/twitter-forks/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java) is used to sort records in-memory. It internally uses a [SimpleCollectingOutputView](https://github.com/twitter-forks/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SimpleCollectingOutputView.java) instantiated using a fixed chunk of managed memory to store the records. When the SimpleCollectingOutputView runs out of memory segments, it [throws an EOFException](https://github.com/twitter-forks/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/SimpleCollectingOutputView.java#L76) which [should be caught by the sorter in the write method
](https://github.com/twitter-forks/flink/blob/master/flink-runtime/src/main/java/org/apache/flink/runtime/operators/sort/NormalizedKeySorter.java#L298) and a `false` indicating that the sort buffer was full (javadoc). The issue here is that the EOFException thrown by the SimpleCollectingOutputView is first caught by the record serializer which offers no guarantee on passing on the exception as it was caught upwards. In the case of Kryo and Thrift, the serializer wraps the caught exception in their own exception classes and throw them upwards which the sorter doesn't catch and the job crashes.

Example stacktrace - 
```
java.lang.RuntimeException: Error obtaining the sorted input: Thread 'SortMerger Reading Thread' terminated due to an exception: java.io.EOFException: Can't collect further: memorySource depleted
    at org.apache.flink.runtime.operators.BatchTask.run(BatchTask.java:487)
    at org.apache.flink.runtime.operators.BatchTask.invoke(BatchTask.java:357)
    at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:935)
    at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:914)
    at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:728)
    at org.apache.flink.runtime.taskmanager.Task.run(Task.java:550)
    at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.apache.flink.util.WrappingRuntimeException: java.util.concurrent.ExecutionException: java.lang.RuntimeException: Error obtaining the sorted input: Thread 'SortMerger Reading Thread' terminated due to an exception: java.io.EOFException: Can't collect further: memorySource depleted
    at org.apache.flink.runtime.operators.sort.ExternalSorter.getIterator(ExternalSorter.java:262)
    at org.apache.flink.runtime.operators.BatchTask.getInput(BatchTask.java:1222)
    at org.apache.flink.runtime.operators.GroupReduceDriver.prepare(GroupReduceDriver.java:105)
    at org.apache.flink.runtime.operators.BatchTask.run(BatchTask.java:479)
    ... 6 more
Caused by: java.util.concurrent.ExecutionException: java.lang.RuntimeException: Error obtaining the sorted input: Thread 'SortMerger Reading Thread' terminated due to an exception: java.io.EOFException: Can't collect further: memorySource depleted
    at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395)
    at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1999)
    at org.apache.flink.runtime.operators.sort.ExternalSorter.getIterator(ExternalSorter.java:259)
    ... 9 more
Caused by: java.lang.RuntimeException: Error obtaining the sorted input: Thread 'SortMerger Reading Thread' terminated due to an exception: java.io.EOFException: Can't collect further: memorySource depleted
    at org.apache.flink.runtime.operators.sort.ExternalSorter.lambda$getIterator$1(ExternalSorter.java:256)
    at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:986)
    at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:970)
    at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
    at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
    at org.apache.flink.runtime.operators.sort.ExternalSorterBuilder.lambda$doBuild$1(ExternalSorterBuilder.java:397)
    at org.apache.flink.runtime.operators.sort.ThreadBase.internalHandleException(ThreadBase.java:121)
    at org.apache.flink.runtime.operators.sort.ThreadBase.run(ThreadBase.java:75)
Caused by: java.io.IOException: Thread 'SortMerger Reading Thread' terminated due to an exception: java.io.EOFException: Can't collect further: memorySource depleted
    at org.apache.flink.runtime.operators.sort.ThreadBase.run(ThreadBase.java:80)
Caused by: com.esotericsoftware.kryo.KryoException: java.io.EOFException: Can't collect further: memorySource depleted
    at com.esotericsoftware.kryo.io.Output.flush(Output.java:165)
    at com.esotericsoftware.kryo.io.OutputChunked.flush(OutputChunked.java:45)
    at com.esotericsoftware.kryo.io.OutputChunked.endChunks(OutputChunked.java:82)
    at com.twitter.beam.coder.scala.ChillCoder.encode(ChillCoder.scala:101)
    at com.twitter.eventwrangler.core.attribution.AttributionEventCoder.encode(AttributionEvent.scala:40)
    at com.twitter.eventwrangler.core.attribution.AttributionEventCoder.encode(AttributionEvent.scala:22)
    at org.apache.beam.sdk.coders.Coder.encode(Coder.java:136)
    at org.apache.beam.sdk.transforms.join.UnionCoder.encode(UnionCoder.java:74)
    at org.apache.beam.sdk.transforms.join.UnionCoder.encode(UnionCoder.java:32)
    at org.apache.beam.sdk.coders.KvCoder.encode(KvCoder.java:73)
    at org.apache.beam.sdk.coders.KvCoder.encode(KvCoder.java:37)
    at org.apache.beam.sdk.util.WindowedValue$FullWindowedValueCoder.encode(WindowedValue.java:607)
    at org.apache.beam.sdk.util.WindowedValue$FullWindowedValueCoder.encode(WindowedValue.java:598)
    at org.apache.beam.sdk.util.WindowedValue$FullWindowedValueCoder.encode(WindowedValue.java:558)
    at org.apache.beam.runners.flink.translation.types.CoderTypeSerializer.serialize(CoderTypeSerializer.java:110)
    at org.apache.flink.api.java.typeutils.runtime.TupleSerializer.serialize(TupleSerializer.java:140)
    at org.apache.flink.api.java.typeutils.runtime.TupleSerializer.serialize(TupleSerializer.java:37)
    at org.apache.flink.runtime.operators.sort.NormalizedKeySorter.write(NormalizedKeySorter.java:297)
    at org.apache.flink.runtime.operators.sort.SorterInputGateway.writeRecord(SorterInputGateway.java:77)
    at org.apache.flink.runtime.operators.sort.ReadingThread.go(ReadingThread.java:69)
    at org.apache.flink.runtime.operators.sort.ThreadBase.run(ThreadBase.java:73)
Caused by: java.io.EOFException: Can't collect further: memorySource depleted
    at org.apache.flink.runtime.io.disk.SimpleCollectingOutputView.nextSegment(SimpleCollectingOutputView.java:76)
    at org.apache.flink.runtime.memory.AbstractPagedOutputView.advance(AbstractPagedOutputView.java:139)
    at org.apache.flink.runtime.memory.AbstractPagedOutputView.write(AbstractPagedOutputView.java:205)
    at org.apache.beam.runners.flink.translation.wrappers.DataOutputViewWrapper.write(DataOutputViewWrapper.java:44)
    at com.esotericsoftware.kryo.io.Output.flush(Output.java:163)
    ... 20 more
```

## Brief change log
  - Check if the nested exception is an EOFException in org.apache.flink.runtime.operators.sort.NormalizedKeySorter#write


## Verifying this change

Was able to replicate the issue in the wordcount job but reducing managed memory to 500MB and modifying the job to count per tweet (which is a Thrift object) so that the Thrift serializer is used in the GroupReduce step. With these changes and the default build, the job crashes. With the change in this PR, it completes successfully while printing out the added log message.

